### PR TITLE
(fix): When browsing a file, typing 'h' will send an error. close #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ tests/pigit-dev_zsh_comp
 tests/pigit_bash_comp
 tests/pigit_fish_comp
 tests/ignore_test
+
+debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,52 @@
-^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog of pigit
-^^^^^^^^^^^^^^^^^^^^^^^^
+# Changelog of pigit
 
-v1.5.0 (2022-02-26)
-----------
+## v1.5.0 (2022-02-26)
 - Refactor code, split sub-command of usage.
 - Refactor shell completion.
 - Refactor args parser.
-- Feat function, add ``repo`` option.
-- Feat function, add ``open`` option.
+- Feat function, add `repo` option.
+- Feat function, add `open` option.
 - Fix color error of print original git command.
 - Fix some logic bug of TUI.
 - Fix can't process chinese error of TUI.
 - Update config.
-- Remove useless function: ``tomato``.
+- Remove useless function: `tomato`.
 
-v1.3.6 (2022-02-10)
-----------
-- Console add ``--alias`` command.
+## v1.3.6 (2022-02-10)
+- Console add `--alias` command.
 - Interaction mode add ignore fuc.
 - Add new short git command about submodule.
 - Update log info more clear.
 
-v1.3.5 (2022-01-15)
-----------
+## v1.3.5 (2022-01-15)
 - Refactor part of code.
-- Fix ``ue`` command about setting global user and email.
-- Fix ``--create-config`` command when don't have config.
+- Fix `ue` command about setting global user and email.
+- Fix `--create-config` command when don't have config.
 
-v1.3.4 (2021-12-26)
-----------
+## v1.3.4 (2021-12-26)
 - Split TUI module.
 - Refactor interaction mode.
 - Add branch model of interaction.
 
-v1.3.3 (2021-11-05)
-----------
+## v1.3.3 (2021-11-05)
 - Optimize CodeCounter.
 - Refactor shell completion.
 - Dep update to Python3.8
 - Optimize shell mode.
 
-v1.3.2 (2021-10-11)
-----------
+## v1.3.2 (2021-10-11)
 - Fix table class for chinese and color.
 - Fix get repo path error when in submodule repo.
-- Adjust the command line parameters, ``pigit -h`` to view.
+- Adjust the command line parameters, `pigit -h` to view.
 - Simple interactive interface support commit part.
 
-v1.3.1 (2021-09-28)
-----------
+## v1.3.1 (2021-09-28)
 - Add new git short command (submodule).
 - Add new config option.
 - Add table class.
 - Improve code logic and format.
 
-v1.3.0 (2021-09-09)
-----------
+## v1.3.0 (2021-09-09)
 - Not continue support Python2.
 - Update config and config template.
 - Improve code counter running speed.
@@ -64,69 +54,60 @@ v1.3.0 (2021-09-09)
 - Fix color command error.
 - Add simple shell mode.
 
-v1.0.9 (2021-08-24)
-----------
+## v1.0.9 (2021-08-24)
 - Update owned commands.
 - Supported interaction of windows.
 - Improved CodeCounter.
 - Fixed some error.
 - Update documents.
 
-v1.0.8 (2021-08-18)
-----------
+## v1.0.8 (2021-08-18)
 - Split package.
 - Fixed shell completion.
 - Allow setting custom cmds.
 
-v1.0.7 (2021-08-11)
-----------
+## v1.0.7 (2021-08-11)
 - Refactor config.
 - Compat with python2 of interactive mode.
 - Add delete and editor in interactive.
 
-v1.0.6 (2021-08-08)
-----------
+## v1.0.6 (2021-08-08)
 - Rename project, pygittools -> pigit
 - Added configuration.
 - Added interactive file tree operation.
-- Allowed some command combined use, like: ``-if``.
+- Allowed some command combined use, like: `-if`.
 - Optimized ignore matching algorithm of CodeCounter.
 - Increase the output mode of CodeCounter. [table, simple]
 - Refactor Git command processor.
 - Refactor Completion, support fish shell.
 - Fix emoji error on windows.
 
-v1.0.4 (2021-08-04)
-----------
+## v1.0.4 (2021-08-04)
 - Optimized recommendation algorithm.
 - Optimize the output of CodeCounter results.
 - Repair CodeCounter matching rule.
 - Compatible with windows.
 
-v1.0.3 (2021-08-02)
-----------
+## v1.0.3 (2021-08-02)
 - Support code statistics.
 - Support command correction.
 - Update completion.
 
-v1.0.2 (2021-07-30)
-----------
+## v1.0.2 (2021-07-30)
 - Add debug mode.
 - Update completion function.
-- Support create ``.gitignore`` template according to given type.
+- Support create `.gitignore` template according to given type.
 - Show runtime.
 - Improve print, more color and beautiful.
 - Fix color compatibility with python2.
 
-v1.0.1 (2021-07-28)
-----------
+## v1.0.1 (2021-07-28)
 - Support quick view of GIT config
 - Support to display warehouse information
 - Improve description.
 - Improve help message.
 
-v1.0.0 (2021-07-20)
-----------
+## v1.0.0 (2021-07-20)
 - Fist release.
 - Support Python2.7 and Python3.
 - Can use short git command.

--- a/pigit/common/git.py
+++ b/pigit/common/git.py
@@ -490,11 +490,16 @@ class GitOption:
         else:
             raise GitOptionError("`file` only allow 'str' or 'File'.") from None
 
+        if "->" in file_name:
+            file_name = file_name.split("->")[-1].strip()
+
         return file_name
 
     def switch_file_status(self, file: Union[File, str], path: Optional[str] = None):
         path = path or self.op_path
         file_name = self._get_file_str(file)
+        # with open("./debug.log", "a+") as f:
+        #     f.write(f"{file_name}\n")
 
         if file.has_merged_conflicts or file.has_inline_merged_conflicts:
             pass

--- a/pigit/render/box.py
+++ b/pigit/render/box.py
@@ -1,7 +1,9 @@
-from typing import Iterable, List, Literal
-import platform
+from typing import Iterable, List, Literal, TYPE_CHECKING
 
 from ._loop import loop_last
+
+if TYPE_CHECKING:
+    from .console import Console
 
 
 class Box:
@@ -67,11 +69,11 @@ class Box:
     def __str__(self) -> str:
         return self._box
 
-    def substitute(self, encoding: str) -> "Box":
+    def substitute(self, console: "Console") -> "Box":
         box = self
-        if platform.system == "Windows":
+        if console.system == "Windows":
             box = WINDOWS_SUBSTITUTIONS.get(box, box)
-        if not encoding.startswith("utf"):
+        if not console.encoding.startswith("utf"):
             box = ASCII
 
         return box

--- a/pigit/render/console.py
+++ b/pigit/render/console.py
@@ -1,5 +1,5 @@
 from typing import Any, Iterable, List, Optional, Union
-import sys
+import sys, platform
 from itertools import islice
 from inspect import isclass
 from shutil import get_terminal_size
@@ -30,6 +30,15 @@ class Console:
     @property
     def hight(self):
         return self.size.lines
+
+    @property
+    def system(self) -> str:
+        """Return the OS name.
+
+        Values: 'Linux', 'Darwin', 'Java', 'Window', ''
+        """
+
+        return platform.system()
 
     @property
     def encoding(self):

--- a/pigit/render/str_utils.py
+++ b/pigit/render/str_utils.py
@@ -150,6 +150,37 @@ def set_cell_size(text: str, total: int) -> str:
             start = pos
 
 
+def wrap_color_str(line: str, width: int):
+    """Warp a colored line.
+    Wrap a colored string according to the width of the restriction.
+    Args:
+        line: A colored string.
+        width: Limit width.
+    """
+    # line = re.sub(r"\x1b(?P<need>\[\d+;*\d*[suABCDf])", "\g<need>", line)
+    # line = line.replace("\\", "\\\\")
+    line_len = len(line)
+    lines = []
+    start = 0
+    i = 0
+    count = 0
+    while i < line_len:
+        if line[i] == "\x1b":
+            while line[i] not in ["m"]:
+                i += 1
+        i += 1
+        count += get_char_width(line[i]) if i < line_len else 0
+        if count + 1 >= width - 1:
+            i += 1
+            lines.append(line[start:i])
+            start = i
+            count = 0
+    if start < line_len:
+        lines.append(line[start:])
+
+    return lines
+
+
 def shorten(
     text: str, width: int, placeholder: str = "...", front: bool = False
 ) -> str:

--- a/pigit/render/table.py
+++ b/pigit/render/table.py
@@ -221,7 +221,7 @@ class Table(BaseTb):
         show_lines = self.show_lines
         show_header = self.show_header
 
-        _box = self.box.substitute(console.encoding) if self.box else None
+        _box = self.box.substitute(console) if self.box else None
         new_line = Segment.line()
 
         if _box:
@@ -528,7 +528,7 @@ class UintTable(BaseTb):
         show_lines = self.show_lines
         show_header = self.show_header
 
-        _box = self.box.substitute(console.encoding) if self.box else None
+        _box = self.box.substitute(console) if self.box else None
         new_line = Segment.line()
 
         if _box:

--- a/pigit/tui/event_loop.py
+++ b/pigit/tui/event_loop.py
@@ -1,12 +1,16 @@
 # -*- coding:utf-8 -*-
-from typing import Callable
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .screen import Screen
 
 
-class ExitLoop(Exception):
-    pass
+class ExitEventLoop(Exception):
+    """Get to exit current event loop."""
 
 
-class Loop(object):
+class EventLoop(object):
     """
     Params:
         screen (Screen): screen to use, default is a new :class:`.screen.Screen`.
@@ -16,7 +20,7 @@ class Loop(object):
 
     def __init__(
         self,
-        screen=None,
+        screen: "Screen" = None,
         input_handle=None,
         real_time: bool = False,
         debug: bool = False,
@@ -41,7 +45,7 @@ class Loop(object):
             self.is_mouse_event = is_mouse_event
         self._input_handle = input_handle
 
-    def set_input_timeouts(self, timeout):
+    def set_input_timeouts(self, timeout: float):
         self._input_handle.set_input_timeouts(timeout)
 
     def _loop(self):
@@ -62,7 +66,7 @@ class Loop(object):
         try:
             while True:
                 self._loop()
-        except (ExitLoop, KeyboardInterrupt):
+        except (ExitEventLoop, KeyboardInterrupt, IOError):
             self._input_handle.stop()
 
     def run(self):


### PR DESCRIPTION
The reson is no implementation method `keyevent_help`. It will raise
a error, 'NoneType' can't plus with 'str'. Introduce `ABC` to check for
errors before running.
    And fix another bug -- don't process a special file string, like:
'a.txt -> b.txt'. It will result in failure to get the correct file name.
    Change the CHANGELOG type from 'rst' to 'md', it's a better way of
using markdown.