### PR TITLE
(fix): `repo ll` has erro when the repos include invalid path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tests/pigit_fish_comp
 tests/ignore_test
 
 debug.log
+xxx_bash_comp

--- a/docs/pigit-dev_zsh_comp
+++ b/docs/pigit-dev_zsh_comp
@@ -148,6 +148,7 @@ __rename_values() {
 __ll_values() {
   _values '' \
     {-h,--help}'[show this help message and exit]' \
+    '--revese[revese to display invalid repo.]' \
     '--simple[display simple summary.]' \
   && ret=0
 }

--- a/docs/pigit_bash_comp
+++ b/docs/pigit_bash_comp
@@ -2,7 +2,7 @@
 
 _pigit_completion(){
   if [[ "${COMP_CWORD}" == "1" ]];then
-      COMP_WORD="-h --help -i --information -f --config -r --report -v --version -c --count --create-ignore -C --complete --create-config cmd -h --help -s --show-commands -p --show-part-command -t --types --shell repo -h --help open -h --help -i --issue -c --commit -p --print add -h --help --dry-run rm -h --help --path rename -h --help ll -h --help --simple clear -h --help fetch -h --help pull -h --help push -h --help b bc bl bL bs bS bm bM bd c ca cA cm co cO cf cF cr cR cs Cl Ca Ce Co CO Ct CT f fc fC fm fr fu fb ia iA iu id iD ir iR ix iX l l1 ls ld lv lc lr m ma mC mF mS mv mt p pf pF pa pA pt pc pp R Rl Ra Rx Rm Ru Rp Rs RS s sp sl sd sD t ta tx ws wS wd wD wr wR wc wC wm wM wx wX Sc Si Su Sd SD savepd ue user email"
+      COMP_WORD="-h --help -i --information -f --config -r --report -v --version -c --count --create-ignore -C --complete --create-config cmd -h --help -s --show-commands -p --show-part-command -t --types --shell repo -h --help open -h --help -i --issue -c --commit -p --print add -h --help --dry-run rm -h --help --path rename -h --help ll -h --help --revese --simple clear -h --help fetch -h --help pull -h --help push -h --help b bc bl bL bs bS bm bM bd c ca cA cm co cO cf cF cr cR cs Cl Ca Ce Co CO Ct CT f fc fC fm fr fu fb ia iA iu id iD ir iR ix iX l l1 ls ld lv lc lr m ma mC mF mS mv mt p pf pF pa pA pt pc pp R Rl Ra Rx Rm Ru Rp Rs RS s sp sl sd sD t ta tx ws wS wd wD wr wR wc wC wm wM wx wX Sc Si Su Sd SD savepd ue user email"
       COMPREPLY=($(compgen -W "$COMP_WORD" -- ${COMP_WORDS[${COMP_CWORD}]}))
   fi
 }

--- a/docs/pigit_fish_comp
+++ b/docs/pigit_fish_comp
@@ -1,7 +1,7 @@
 function _pigit_completion;
     set -l response;
 
-    for value in (env -h --help -i --information -f --config -r --report -v --version -c --count --create-ignore -C --complete --create-config cmd -h --help -s --show-commands -p --show-part-command -t --types --shell repo -h --help open -h --help -i --issue -c --commit -p --print add -h --help --dry-run rm -h --help --path rename -h --help ll -h --help --simple clear -h --help fetch -h --help pull -h --help push -h --help b bc bl bL bs bS bm bM bd c ca cA cm co cO cf cF cr cR cs Cl Ca Ce Co CO Ct CT f fc fC fm fr fu fb ia iA iu id iD ir iR ix iX l l1 ls ld lv lc lr m ma mC mF mS mv mt p pf pF pa pA pt pc pp R Rl Ra Rx Rm Ru Rp Rs RS s sp sl sd sD t ta tx ws wS wd wD wr wR wc wC wm wM wx wX Sc Si Su Sd SD savepd ue user email=fish_complete COMP_WORDS=(commandline -cp)         COMP_CWORD=(commandline -t) pigit);
+    for value in (env -h --help -i --information -f --config -r --report -v --version -c --count --create-ignore -C --complete --create-config cmd -h --help -s --show-commands -p --show-part-command -t --types --shell repo -h --help open -h --help -i --issue -c --commit -p --print add -h --help --dry-run rm -h --help --path rename -h --help ll -h --help --revese --simple clear -h --help fetch -h --help pull -h --help push -h --help b bc bl bL bs bS bm bM bd c ca cA cm co cO cf cF cr cR cs Cl Ca Ce Co CO Ct CT f fc fC fm fr fu fb ia iA iu id iD ir iR ix iX l l1 ls ld lv lc lr m ma mC mF mS mv mt p pf pF pa pA pt pc pp R Rl Ra Rx Rm Ru Rp Rs RS s sp sl sd sD t ta tx ws wS wd wD wr wR wc wC wm wM wx wX Sc Si Su Sd SD savepd ue user email=fish_complete COMP_WORDS=(commandline -cp)         COMP_CWORD=(commandline -t) pigit);
         set response $response $value;
     end;
 

--- a/pigit/common/utils.py
+++ b/pigit/common/utils.py
@@ -43,8 +43,8 @@ def exec_cmd(
     _stderr: Optional[int] = subprocess.PIPE if reply else None
     _stdout: Optional[int] = subprocess.PIPE if reply else None
 
-    _error: Union[str, ByteString, None] = None
-    _result: Union[str, ByteString, None] = None
+    _err: Union[str, ByteString, None] = None
+    _rlt: Union[str, ByteString, None] = None
 
     try:
         # Take over the input stream and get the return information.
@@ -52,18 +52,20 @@ def exec_cmd(
             " ".join(args), stderr=_stderr, stdout=_stdout, shell=True, cwd=cwd
         ) as proc:
             outres, errres = proc.communicate()
-    except (FileNotFoundError,) as e:
-        _error = str(e).encode()
+    except FileNotFoundError as e:
+        _err = str(e).encode()
     else:
-        _error, _result = errres, outres
+        _err, _rlt = errres, outres
 
-    if decoding:
-        return (
-            _error is not None and _error.decode(),
-            _result is not None and _result.decode(),
-        )
-    else:
-        return _error, _result
+    if not decoding:
+        return _err, _rlt
+
+    # decode
+    if _err is not None:
+        _err = _err.decode()
+    if _rlt is not None:
+        _rlt = _rlt.decode()
+    return _err, _rlt
 
 
 async def async_run_cmd(

--- a/pigit/entry.py
+++ b/pigit/entry.py
@@ -229,13 +229,27 @@ def repo_rename(args, _):
 
 @repo.sub_parser("ll", help="display summary of all repos.")
 @argument("--simple", action="store_true", help="display simple summary.")
+@argument("--revese", action="store_true", help="revese to display invalid repo.")
 def repo_ll(args, _):
-    for info in git.ll_repos():
-        if args.simple:
-            console.echo(f"{info[0][0]:<20} {info[1][1]:<15} {info[5][1]}")
+    simple = args.simple
+    revese = args.revese
+
+    for info in git.ll_repos(revese=revese):
+        if simple:
+            if revese:
+                console.echo(f"{info[0][0]:<20} {info[1][1]:<15}")
+            else:
+                console.echo(f"{info[0][0]:<20} {info[1][1]:<15} {info[5][1]}")
         else:
-            console.echo(
-                textwrap.dedent(
+            if revese:
+                summary_string = textwrap.dedent(
+                    f"""\
+                    b`{info[0][0]}`
+                        {info[1][0]}: `{info[1][1]}`<sky_blue>
+                    """
+                )
+            else:
+                summary_string = textwrap.dedent(
                     f"""\
                     b`{info[0][0]}`
                         {info[1][0]}: {info[1][1]}
@@ -245,7 +259,7 @@ def repo_ll(args, _):
                         {info[5][0]}: `{info[5][1]}`<sky_blue>
                     """
                 )
-            )
+            console.echo(summary_string)
 
 
 repo.sub_parser("clear", help="clear the all repos.")(lambda _, __: git.clear_repos())

--- a/pigit/gitlib/processor.py
+++ b/pigit/gitlib/processor.py
@@ -73,8 +73,8 @@ class ShortGitter(metaclass=Singleton):
         """
 
         handle = re.match(r"(\w+)\s+(\w+)", command)
-        prop = handle.group(1)
-        cmd = handle.group(2)
+        prop = handle[1]
+        cmd = handle[2]
         next_position = handle.span()[1]
 
         color_command = f"b`{prop}`<ok> b`{cmd}`<goldenrod> "


### PR DESCRIPTION
- The season is cannot get result of git when the path is invalid. The
  head will be `None` when path is invalid. So through adjust the value
  of head to select whether continue.
- Follow the feature, add `--revese` for `repo ll` to display all
  invalid repo.