### PR TITLE
(fix): switch file status faild, when file path with space. #close 33

### DIFF
--- a/pigit/const.py
+++ b/pigit/const.py
@@ -3,7 +3,7 @@
 import os, platform, datetime
 
 __project__ = "pigit"
-__version__ = "1.5.2"
+__version__ = "1.5.3-dev"
 __url__ = "https://github.com/zlj-zz/pigit.git"
 __uri__ = __url__
 

--- a/pigit/entry.py
+++ b/pigit/entry.py
@@ -1,7 +1,7 @@
 # -*- coding:utf-8 -*-
 # The PIGIT terminal tool entry file.
 
-from typing import List
+from typing import Dict, List
 import os, logging, textwrap
 
 from .log import setup_logging
@@ -39,7 +39,7 @@ CONFIG = Config(
 
 setup_logging(
     debug=CONFIG.debug_open,
-    log_file=LOG_FILE_PATH if CONFIG.log_output else None,
+    log_file=None if CONFIG.log_output else LOG_FILE_PATH,
 )
 
 
@@ -151,7 +151,7 @@ def _cmd_func(args: Namespace, unknown: List):
         git.add_repos([repo_path])
 
     # Init extra custom cmds.
-    extra_cmd: dict = {
+    extra_cmd: Dict = {
         # "shell": {
         #     "command": lambda _: shell_mode(git_processor),
         #     "type": "func",

--- a/pigit/gitlib/options.py
+++ b/pigit/gitlib/options.py
@@ -508,18 +508,16 @@ class GitOption:
     def switch_file_status(self, file: Union[File, str], path: Optional[str] = None):
         path = path or self.op_path
         file_name = self._get_file_str(file)
-        # with open("./debug.log", "a+") as f:
-        #     f.write(f"{file_name}\n")
 
         if file.has_merged_conflicts or file.has_inline_merged_conflicts:
             pass
         elif file.has_unstaged_change:
-            exec_cmd(f"git add -- {file_name}", cwd=path)
+            exec_cmd(f"git add -- '{file_name}'", cwd=path)
         elif file.has_staged_change:
             if file.tracked:
-                exec_cmd(f"git reset HEAD -- {file_name}", cwd=path)
+                exec_cmd(f"git reset HEAD -- '{file_name}'", cwd=path)
             else:
-                exec_cmd(f"git rm --cached --force -- {file_name}", cwd=path)
+                exec_cmd(f"git rm --cached --force -- '{file_name}'", cwd=path)
 
     def discard_file(
         self,

--- a/pigit/interaction.py
+++ b/pigit/interaction.py
@@ -1,6 +1,6 @@
 # -*- coding:utf-8 -*-
 from typing import TYPE_CHECKING, List, Optional, Any
-import os
+import os, logging
 from time import sleep
 
 from .const import IS_WIN
@@ -11,10 +11,11 @@ from .render import get_console
 from .render.style import Style
 from .gitlib.options import GitOption
 
-
 if TYPE_CHECKING:
     from .gitlib.model import File, Commit, Branch
 
+
+Logger = logging.getLogger(__name__)
 
 # git option handler
 git = GitOption()


### PR DESCRIPTION
- The faild reason is the file path with space. So the easy way is that
  wrapping the file path in quotation marks.